### PR TITLE
Use curly quotation marks for literal boxes

### DIFF
--- a/lib/nodes/literal.js
+++ b/lib/nodes/literal.js
@@ -12,7 +12,7 @@ var base_text_attrs = {
     };
 
 function Literal(paper, structure) {
-    TextBox.call(this, paper, '"' + structure.content + '"',
+    TextBox.call(this, paper, '“' + structure.content + '”',
         base_text_attrs, base_rect_attrs);
 }
 


### PR DESCRIPTION
Marginally easier to read than """""" (now it's “""""”).
